### PR TITLE
Refactor into simple services

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
 # Simple CMS Admin Panel
 
-This repository provides a minimal example of a website builder using a PHP backend with a React frontend and MySQL storage.
+This repository provides a minimal example of a website builder using a PHP backend with a React frontend and MySQL storage. The backend is split into small services for easier extension.
 
 ## Structure
 
-- `backend/` – PHP API for managing pages stored in MySQL.
-- `frontend/` – small React application for editing pages.
+- `backend/` – PHP services and API endpoints
+- `backend/services/` – individual service classes (pages, auth, SEO, etc.)
+- `public/admin/` – React application available under `/admin`
 
 ## Database
 
@@ -20,9 +21,8 @@ CREATE TABLE cms.pages (
 );
 ```
 
-Alternatively run `install.php` in your browser and follow the form to create
-the database and configuration automatically.
+Alternatively run `install.php` in your browser and follow the form to create the database and configuration automatically.
 
 ## Running
 
-Serve the `frontend` and `backend` folders with a web server that supports PHP. The React code uses simple fetch requests to the PHP API.
+Serve the repository with a web server that supports PHP. The React admin is accessible at `/admin` and communicates with the PHP API in `backend/`.

--- a/backend/login.php
+++ b/backend/login.php
@@ -3,12 +3,13 @@ session_start();
 header('Content-Type: application/json');
 
 $config = include __DIR__ . '/config.php';
-$adminUser = $config['admin_user'] ?? 'admin';
-$adminPass = $config['admin_password'] ?? 'password';
+require __DIR__ . '/services/AuthService.php';
+
+$auth = new AuthService($config);
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $data = json_decode(file_get_contents('php://input'), true);
-    if (($data['username'] ?? '') === $adminUser && ($data['password'] ?? '') === $adminPass) {
+    if ($auth->checkCredentials($data['username'] ?? '', $data['password'] ?? '')) {
         $_SESSION['logged_in'] = true;
         echo json_encode(['success' => true]);
     } else {

--- a/backend/services/AuthService.php
+++ b/backend/services/AuthService.php
@@ -1,0 +1,14 @@
+<?php
+class AuthService {
+    private string $adminUser;
+    private string $adminPass;
+
+    public function __construct(array $config) {
+        $this->adminUser = $config['admin_user'] ?? 'admin';
+        $this->adminPass = $config['admin_password'] ?? 'password';
+    }
+
+    public function checkCredentials(string $username, string $password): bool {
+        return $username === $this->adminUser && $password === $this->adminPass;
+    }
+}

--- a/backend/services/BuilderService.php
+++ b/backend/services/BuilderService.php
@@ -1,0 +1,6 @@
+<?php
+class BuilderService {
+    public function buildTemplate(string $title, string $content): string {
+        return "<article><header><h1>$title</h1></header><div>$content</div></article>";
+    }
+}

--- a/backend/services/PageService.php
+++ b/backend/services/PageService.php
@@ -1,0 +1,36 @@
+<?php
+class PageService {
+    private PDO $pdo;
+
+    public function __construct(PDO $pdo) {
+        $this->pdo = $pdo;
+    }
+
+    public function getAll(): array {
+        $stmt = $this->pdo->query('SELECT * FROM pages ORDER BY id DESC');
+        return $stmt->fetchAll();
+    }
+
+    public function get(int $id): ?array {
+        $stmt = $this->pdo->prepare('SELECT * FROM pages WHERE id = ?');
+        $stmt->execute([$id]);
+        $page = $stmt->fetch();
+        return $page ?: null;
+    }
+
+    public function create(string $title, string $content): int {
+        $stmt = $this->pdo->prepare('INSERT INTO pages (title, content) VALUES (?, ?)');
+        $stmt->execute([$title, $content]);
+        return (int)$this->pdo->lastInsertId();
+    }
+
+    public function update(int $id, string $title, string $content): void {
+        $stmt = $this->pdo->prepare('UPDATE pages SET title = ?, content = ? WHERE id = ?');
+        $stmt->execute([$title, $content, $id]);
+    }
+
+    public function delete(int $id): void {
+        $stmt = $this->pdo->prepare('DELETE FROM pages WHERE id = ?');
+        $stmt->execute([$id]);
+    }
+}

--- a/backend/services/RenderService.php
+++ b/backend/services/RenderService.php
@@ -1,0 +1,16 @@
+<?php
+class RenderService {
+    private PageService $pages;
+
+    public function __construct(PageService $pages) {
+        $this->pages = $pages;
+    }
+
+    public function render(int $id): string {
+        $page = $this->pages->get($id);
+        if (!$page) {
+            return 'Page not found';
+        }
+        return "<h1>" . htmlspecialchars($page['title']) . "</h1>\n" . $page['content'];
+    }
+}

--- a/backend/services/SEOService.php
+++ b/backend/services/SEOService.php
@@ -1,0 +1,10 @@
+<?php
+class SEOService {
+    public function meta(string $title): array {
+        $slug = strtolower(preg_replace('/[^a-z0-9]+/i', '-', $title));
+        return [
+            'title' => $title,
+            'slug' => trim($slug, '-')
+        ];
+    }
+}

--- a/backend/services/SettingsService.php
+++ b/backend/services/SettingsService.php
@@ -1,0 +1,12 @@
+<?php
+class SettingsService {
+    private string $file;
+
+    public function __construct(string $file) {
+        $this->file = $file;
+    }
+
+    public function get(): array {
+        return include $this->file;
+    }
+}

--- a/public/admin/app.js
+++ b/public/admin/app.js
@@ -1,0 +1,115 @@
+class App extends React.Component {
+  state = {
+    pages: [],
+    title: '',
+    content: '',
+    editingId: null,
+    loggedIn: false,
+    username: '',
+    password: ''
+  };
+
+  componentDidMount() {
+    fetch('../backend/login.php')
+      .then(res => res.json())
+      .then(res => {
+        if (res.logged_in) {
+          this.setState({ loggedIn: true }, this.loadPages);
+        }
+      });
+  }
+
+  loadPages = () => {
+    fetch('../backend/api.php')
+      .then(res => res.json())
+      .then(pages => this.setState({ pages }));
+  };
+
+  login = () => {
+    fetch('../backend/login.php', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ username: this.state.username, password: this.state.password })
+    }).then(res => {
+      if (res.ok) {
+        this.setState({ loggedIn: true }, this.loadPages);
+      } else {
+        alert('Login failed');
+      }
+    });
+  };
+
+  savePage = () => {
+    const { title, content, editingId } = this.state;
+    const method = editingId ? 'PUT' : 'POST';
+    const url = '../backend/api.php' + (editingId ? `?id=${editingId}` : '');
+    fetch(url, {
+      method,
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ title, content })
+    }).then(() => {
+      this.setState({ title: '', content: '', editingId: null });
+      this.loadPages();
+    });
+  };
+
+  editPage = (page) => this.setState({ title: page.title, content: page.content, editingId: page.id });
+
+  deletePage = (id) => {
+    fetch(`../backend/api.php?id=${id}`, { method: 'DELETE' })
+      .then(() => this.loadPages());
+  };
+
+  render() {
+    if (!this.state.loggedIn) {
+      return (
+        <div>
+          <h1>Login</h1>
+          <input
+            placeholder="Username"
+            value={this.state.username}
+            onChange={e => this.setState({ username: e.target.value })}
+          />
+          <br />
+          <input
+            type="password"
+            placeholder="Password"
+            value={this.state.password}
+            onChange={e => this.setState({ password: e.target.value })}
+          />
+          <br />
+          <button onClick={this.login}>Login</button>
+        </div>
+      );
+    }
+    return (
+      <div>
+        <h1>CMS Admin</h1>
+        <input
+          placeholder="Title"
+          value={this.state.title}
+          onChange={e => this.setState({ title: e.target.value })}
+        />
+        <br />
+        <textarea
+          placeholder="Content"
+          value={this.state.content}
+          onChange={e => this.setState({ content: e.target.value })}
+        />
+        <br />
+        <button onClick={this.savePage}>{this.state.editingId ? 'Update' : 'Create'} Page</button>
+        <h2>Pages</h2>
+        {this.state.pages.map(page => (
+          <div key={page.id} className="page">
+            <h3>{page.title}</h3>
+            <div dangerouslySetInnerHTML={{ __html: page.content }} />
+            <button onClick={() => this.editPage(page)}>Edit</button>
+            <button onClick={() => this.deletePage(page.id)}>Delete</button>
+          </div>
+        ))}
+      </div>
+    );
+  }
+}
+
+ReactDOM.render(<App />, document.getElementById('root'));

--- a/public/admin/index.html
+++ b/public/admin/index.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>CMS Admin</title>
+  <script crossorigin src="https://unpkg.com/react@17/umd/react.development.js"></script>
+  <script crossorigin src="https://unpkg.com/react-dom@17/umd/react-dom.development.js"></script>
+  <script crossorigin src="https://unpkg.com/babel-standalone@6/babel.min.js"></script>
+  <style>
+    body { font-family: Arial, sans-serif; margin: 20px; }
+    .page { border: 1px solid #ccc; padding: 10px; margin-bottom: 10px; }
+  </style>
+</head>
+<body>
+  <div id="root"></div>
+  <script type="text/babel" src="app.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- refactor CRUD api to use a `PageService`
- wrap login logic in `AuthService`
- add additional stub service classes
- copy React admin app under `public/admin` so `/admin` can be served as admin panel
- update README with new structure

## Testing
- `php -l backend/api.php`
- `php -l backend/login.php`
- `for f in backend/services/*.php; do php -l $f; done`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684048396a7c832c8ba90831e0ed692f