### PR TITLE
Add installer credentials and basic admin info

### DIFF
--- a/backend/seo.php
+++ b/backend/seo.php
@@ -1,0 +1,8 @@
+<?php
+header('Content-Type: application/json');
+require __DIR__ . '/services/SEOService.php';
+
+$title = $_GET['title'] ?? '';
+$seo = new SEOService();
+
+echo json_encode($seo->meta($title));

--- a/backend/users.php
+++ b/backend/users.php
@@ -1,0 +1,9 @@
+<?php
+header('Content-Type: application/json');
+$config = include __DIR__ . '/config.php';
+
+$users = [
+    ['username' => $config['admin_user']]
+];
+
+echo json_encode($users);

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -3,8 +3,10 @@ class App extends React.Component {
     pages: [],
     title: '',
     content: '',
+    slug: '',
     editingId: null,
     loggedIn: false,
+    users: [],
     username: '',
     password: ''
   };
@@ -14,7 +16,10 @@ class App extends React.Component {
       .then(res => res.json())
       .then(res => {
         if (res.logged_in) {
-          this.setState({ loggedIn: true }, this.loadPages);
+          this.setState({ loggedIn: true }, () => {
+            this.loadPages();
+            this.loadUsers();
+          });
         }
       });
   }
@@ -23,6 +28,12 @@ class App extends React.Component {
     fetch('../backend/api.php')
       .then(res => res.json())
       .then(pages => this.setState({ pages }));
+  };
+
+  loadUsers = () => {
+    fetch('../backend/users.php')
+      .then(res => res.json())
+      .then(users => this.setState({ users }));
   };
 
   login = () => {
@@ -88,7 +99,19 @@ class App extends React.Component {
         <input
           placeholder="Title"
           value={this.state.title}
-          onChange={e => this.setState({ title: e.target.value })}
+          onChange={e => {
+            const title = e.target.value;
+            this.setState({ title });
+            fetch(`../backend/seo.php?title=${encodeURIComponent(title)}`)
+              .then(res => res.json())
+              .then(data => this.setState({ slug: data.slug }));
+          }}
+        />
+        <br />
+        <input
+          placeholder="Slug"
+          value={this.state.slug}
+          readOnly
         />
         <br />
         <textarea
@@ -107,6 +130,12 @@ class App extends React.Component {
             <button onClick={() => this.deletePage(page.id)}>Delete</button>
           </div>
         ))}
+        <h2>Users</h2>
+        <ul>
+          {this.state.users.map(u => (
+            <li key={u.username}>{u.username}</li>
+          ))}
+        </ul>
       </div>
     );
   }

--- a/index.php
+++ b/index.php
@@ -1,0 +1,14 @@
+<?php
+if (!file_exists(__DIR__ . '/backend/config.php')) {
+    header('Location: install.php');
+    exit;
+}
+?><!DOCTYPE html>
+<html>
+<head><meta charset="UTF-8"><title>CMS Installed</title></head>
+<body>
+<h1>CMS Installed</h1>
+<p>The CMS is successfully installed.</p>
+<p><a href="/admin/">Go to admin panel</a></p>
+</body>
+</html>

--- a/install.php
+++ b/install.php
@@ -11,11 +11,16 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $user = $_POST['user'] ?? 'cms_user';
     $password = $_POST['password'] ?? '';
 
+    $adminUser = $_POST['admin_user'] ?? 'admin';
+    $adminPass = $_POST['admin_password'] ?? 'password';
+
     $config = [
         'host' => $host,
         'dbname' => $dbname,
         'user' => $user,
         'password' => $password,
+        'admin_user' => $adminUser,
+        'admin_password' => $adminPass,
     ];
 
     try {
@@ -46,6 +51,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
   <input name="dbname" placeholder="DB Name" value="cms" required><br>
   <input name="user" placeholder="DB User" value="cms_user" required><br>
   <input name="password" placeholder="DB Password" required type="password"><br>
+  <input name="admin_user" placeholder="Admin Username" value="admin" required><br>
+  <input name="admin_password" placeholder="Admin Password" type="password" required><br>
   <button type="submit">Install</button>
 </form>
 </body>

--- a/public/admin/app.js
+++ b/public/admin/app.js
@@ -3,8 +3,10 @@ class App extends React.Component {
     pages: [],
     title: '',
     content: '',
+    slug: '',
     editingId: null,
     loggedIn: false,
+    users: [],
     username: '',
     password: ''
   };
@@ -14,7 +16,10 @@ class App extends React.Component {
       .then(res => res.json())
       .then(res => {
         if (res.logged_in) {
-          this.setState({ loggedIn: true }, this.loadPages);
+          this.setState({ loggedIn: true }, () => {
+            this.loadPages();
+            this.loadUsers();
+          });
         }
       });
   }
@@ -23,6 +28,12 @@ class App extends React.Component {
     fetch('../backend/api.php')
       .then(res => res.json())
       .then(pages => this.setState({ pages }));
+  };
+
+  loadUsers = () => {
+    fetch('../backend/users.php')
+      .then(res => res.json())
+      .then(users => this.setState({ users }));
   };
 
   login = () => {
@@ -88,7 +99,19 @@ class App extends React.Component {
         <input
           placeholder="Title"
           value={this.state.title}
-          onChange={e => this.setState({ title: e.target.value })}
+          onChange={e => {
+            const title = e.target.value;
+            this.setState({ title });
+            fetch(`../backend/seo.php?title=${encodeURIComponent(title)}`)
+              .then(res => res.json())
+              .then(data => this.setState({ slug: data.slug }));
+          }}
+        />
+        <br />
+        <input
+          placeholder="Slug"
+          value={this.state.slug}
+          readOnly
         />
         <br />
         <textarea
@@ -107,6 +130,12 @@ class App extends React.Component {
             <button onClick={() => this.deletePage(page.id)}>Delete</button>
           </div>
         ))}
+        <h2>Users</h2>
+        <ul>
+          {this.state.users.map(u => (
+            <li key={u.username}>{u.username}</li>
+          ))}
+        </ul>
       </div>
     );
   }


### PR DESCRIPTION
## Summary
- let installer set admin credentials
- show install success in `index.php`
- add SEO and user APIs
- expand React admin to display slug and list users

## Testing
- `php -l backend/api.php`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68404b2ab20c832c888e5fcd2a25e5a3