### PR TITLE
Add hosting installation guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,29 @@ Alternatively run `install.php` in your browser and follow the form to create th
 ## Running
 
 Serve the repository with a web server that supports PHP. The React admin is accessible at `/admin` and communicates with the PHP API in `backend/`.
+
+## Installing on Shared Hosting
+
+Follow these steps to deploy the CMS on any typical PHP hosting service:
+
+1. **Prepare the environment**
+   - Make sure your hosting plan supports **PHP 8.0+** and **MySQL**.
+   - Create a new MySQL database and user via your hosting control panel.
+
+2. **Upload the files**
+   - Download this repository or extract an archive of it.
+   - Upload all files to the document root of your website (for example `public_html/`).
+
+3. **Configure the CMS**
+   - Edit `backend/config.php` and fill in the database credentials you created above. You can also set the desired admin username and password in this file.
+   - If you prefer to use the web installer instead, remove `backend/config.php` before uploading and navigate to `install.php` after the upload. The installer will ask for the database settings and create the configuration file for you.
+
+4. **Create the database table**
+   - If you used the installer, this step is handled automatically.
+   - Otherwise execute the SQL snippet from the *Database* section on your new database to create the `pages` table.
+
+5. **Finalize**
+   - After installation, remove `install.php` from the server for security.
+   - Visit `/admin/` in your browser to log in and start managing pages.
+
+The CMS should now be fully functional on your hosting account.


### PR DESCRIPTION
## Summary
- add step-by-step instructions for installing the CMS on shared hosting

## Testing
- `pytest -q` *(fails: FileNotFoundError: No such file or directory: 'mysql')*
- `php -l backend/api.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68404e77f8dc832c9e24783c85194dde