### PR TITLE
Add admin user table

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,11 @@ CREATE TABLE cms.pages (
   title VARCHAR(255) NOT NULL,
   content TEXT NOT NULL
 );
+CREATE TABLE cms.users (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  username VARCHAR(255) NOT NULL UNIQUE,
+  password_hash VARCHAR(255) NOT NULL
+);
 ```
 
 Alternatively run `install.php` in your browser and follow the form to create the database and configuration automatically.
@@ -40,12 +45,12 @@ Follow these steps to deploy the CMS on any typical PHP hosting service:
    - Upload all files to the document root of your website (for example `public_html/`).
 
 3. **Configure the CMS**
-   - Edit `backend/config.php` and fill in the database credentials you created above. You can also set the desired admin username and password in this file.
-   - If you prefer to use the web installer instead, remove `backend/config.php` before uploading and navigate to `install.php` after the upload. The installer will ask for the database settings and create the configuration file for you.
+   - Edit `backend/config.php` and fill in the database credentials you created above.
+   - If you prefer to use the web installer instead, remove `backend/config.php` before uploading and navigate to `install.php` after the upload. The installer will ask for the database settings, create the necessary tables and let you set up an administrator account.
 
-4. **Create the database table**
+4. **Create the database tables**
    - If you used the installer, this step is handled automatically.
-   - Otherwise execute the SQL snippet from the *Database* section on your new database to create the `pages` table.
+   - Otherwise execute the SQL snippet from the *Database* section on your new database to create the `pages` and `users` tables.
 
 5. **Finalize**
    - After installation, remove `install.php` from the server for security.

--- a/backend/config.php
+++ b/backend/config.php
@@ -4,6 +4,4 @@ return [
     'dbname' => 'cms',
     'user' => 'cms_user',
     'password' => 'cms_password',
-    'admin_user' => 'admin',
-    'admin_password' => 'password',
 ];

--- a/backend/login.php
+++ b/backend/login.php
@@ -3,9 +3,10 @@ session_start();
 header('Content-Type: application/json');
 
 $config = include __DIR__ . '/config.php';
+require __DIR__ . '/db.php';
 require __DIR__ . '/services/AuthService.php';
 
-$auth = new AuthService($config);
+$auth = new AuthService($pdo);
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $data = json_decode(file_get_contents('php://input'), true);

--- a/backend/services/AuthService.php
+++ b/backend/services/AuthService.php
@@ -1,14 +1,15 @@
 <?php
 class AuthService {
-    private string $adminUser;
-    private string $adminPass;
+    private PDO $pdo;
 
-    public function __construct(array $config) {
-        $this->adminUser = $config['admin_user'] ?? 'admin';
-        $this->adminPass = $config['admin_password'] ?? 'password';
+    public function __construct(PDO $pdo) {
+        $this->pdo = $pdo;
     }
 
     public function checkCredentials(string $username, string $password): bool {
-        return $username === $this->adminUser && $password === $this->adminPass;
+        $stmt = $this->pdo->prepare('SELECT password_hash FROM users WHERE username = ?');
+        $stmt->execute([$username]);
+        $row = $stmt->fetch();
+        return $row && password_verify($password, $row['password_hash']);
     }
 }

--- a/backend/users.php
+++ b/backend/users.php
@@ -1,9 +1,8 @@
 <?php
 header('Content-Type: application/json');
-$config = include __DIR__ . '/config.php';
+require __DIR__ . '/db.php';
 
-$users = [
-    ['username' => $config['admin_user']]
-];
+$stmt = $pdo->query('SELECT username FROM users ORDER BY id');
+$users = $stmt->fetchAll(PDO::FETCH_ASSOC);
 
 echo json_encode($users);

--- a/install.php
+++ b/install.php
@@ -19,8 +19,6 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         'dbname' => $dbname,
         'user' => $user,
         'password' => $password,
-        'admin_user' => $adminUser,
-        'admin_password' => $adminPass,
     ];
 
     try {
@@ -30,8 +28,14 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         $pdo->exec("CREATE DATABASE IF NOT EXISTS `$dbname`");
         $pdo->exec("USE `$dbname`");
         $pdo->exec("CREATE TABLE IF NOT EXISTS pages (id INT AUTO_INCREMENT PRIMARY KEY, title VARCHAR(255) NOT NULL, content TEXT NOT NULL)");
+        $pdo->exec("CREATE TABLE IF NOT EXISTS users (id INT AUTO_INCREMENT PRIMARY KEY, username VARCHAR(255) NOT NULL UNIQUE, password_hash VARCHAR(255) NOT NULL)");
+
+        $hash = password_hash($adminPass, PASSWORD_DEFAULT);
+        $stmt = $pdo->prepare('INSERT INTO users (username, password_hash) VALUES (?, ?)');
+        $stmt->execute([$adminUser, $hash]);
+
         file_put_contents(__DIR__ . '/backend/config.php', "<?php\nreturn " . var_export($config, true) . ";\n");
-        echo 'Installation successful. Please delete install.php.';
+        echo 'Installation successful. Admin account created. Please delete install.php.';
         exit;
     } catch (PDOException $e) {
         $error = $e->getMessage();


### PR DESCRIPTION
## Summary
- install script now creates a `users` table and initial administrator
- store only DB connection data in `config.php`
- adjust authentication to query users table
- update README with new SQL schema and instructions

## Testing
- `php -l backend/api.php`
- `pytest -q` *(fails: FileNotFoundError: [Errno 2] No such file or directory: 'mysql')*

------
https://chatgpt.com/codex/tasks/task_e_68416ba6d7c4832c9552689bd12c14b8